### PR TITLE
Revise checks on returned attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## devel
+
+* Refine checks on returned attributes
+
 ## 1.0.0 (2018-12-18)
 
 * Generate `<SessionInitiator>` elements according to `ACS_*` environment variables

--- a/README.md
+++ b/README.md
@@ -220,13 +220,51 @@ The environment variables of the example will generate the following configurati
         <OR>
             <!-- Check AttributeConsumingService with index 1 -->
             <AND>
-                <Rule require="SPIDCODE"/>
-                <Rule require="FISCALNUMBER"/>
+                <AND>
+                    <Rule require="SPIDCODE"/>
+                    <Rule require="FISCALNUMBER"/>
+                </AND>
+                <AND>
+                    <NOT><Rule require="ADDRESS"/></NOT>
+                    <NOT><Rule require="COMPANYNAME"/></NOT>
+                    <NOT><Rule require="COUNTYOFBIRTH"/></NOT>
+                    <NOT><Rule require="DATEOFBIRTH"/></NOT>
+                    <NOT><Rule require="DIGITALADDRESS"/></NOT>
+                    <NOT><Rule require="EMAIL"/></NOT>
+                    <NOT><Rule require="EXPIRATIONDATE"/></NOT>
+                    <NOT><Rule require="FAMILYNAME"/></NOT>
+                    <NOT><Rule require="GENDER"/></NOT>
+                    <NOT><Rule require="IDCARD"/></NOT>
+                    <NOT><Rule require="IVACODE"/></NOT>
+                    <NOT><Rule require="MOBILEPHONE"/></NOT>
+                    <NOT><Rule require="NAME"/></NOT>
+                    <NOT><Rule require="PLACEOFBIRTH"/></NOT>
+                    <NOT><Rule require="REGISTEREDOFFICE"/></NOT>
+                </AND>
             </AND>
             <!-- Check AttributeConsumingService with index 27 -->
             <AND>
-                <Rule require="NAME"/>
-                <Rule require="PLACEOFBIRTH"/>
+                <AND>
+                    <Rule require="NAME"/>
+                    <Rule require="PLACEOFBIRTH"/>
+                </AND>
+                <AND>
+                    <NOT><Rule require="ADDRESS"/></NOT>
+                    <NOT><Rule require="COMPANYNAME"/></NOT>
+                    <NOT><Rule require="COUNTYOFBIRTH"/></NOT>
+                    <NOT><Rule require="DATEOFBIRTH"/></NOT>
+                    <NOT><Rule require="DIGITALADDRESS"/></NOT>
+                    <NOT><Rule require="EMAIL"/></NOT>
+                    <NOT><Rule require="EXPIRATIONDATE"/></NOT>
+                    <NOT><Rule require="FAMILYNAME"/></NOT>
+                    <NOT><Rule require="FISCALNUMBER"/></NOT>
+                    <NOT><Rule require="GENDER"/></NOT>
+                    <NOT><Rule require="IDCARD"/></NOT>
+                    <NOT><Rule require="IVACODE"/></NOT>
+                    <NOT><Rule require="MOBILEPHONE"/></NOT>
+                    <NOT><Rule require="REGISTEREDOFFICE"/></NOT>
+                    <NOT><Rule require="SPIDCODE"/></NOT>
+                </AND>
             </AND>
         </OR>
     </AND>

--- a/usr/local/bin/docker-bootstrap.sh
+++ b/usr/local/bin/docker-bootstrap.sh
@@ -214,17 +214,28 @@ for idx in $(echo ${ACS_INDEXES} | tr ';' ' '); do
     cat >> ${ATTR_CHECK} <<EOF
                         <!-- Check AttributeConsumingService with index ${idx} -->
                         <AND>
+                            <AND>
+EOF
+
+    for attr in $(echo ${!_attrs} | tr ';' ' '); do
+        echo "      <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
+    done
+
+    cat >> ${ATTR_CHECK} <<EOF
+                            </AND>
+                            <NOT>
+                                <AND>
 EOF
 
     for attr in ${ATTRIBUTES[*]}; do
-        if echo ${!_attrs} | tr [:lower:] [:upper:] | grep -w -q "${attr}"; then
-            echo "                            <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
-        else
-            echo "                            <RuleRegex require=\"$(echo ${attr} | tr [:lower:] [:upper:])\">^\$</RuleRegex>" >> ${ATTR_CHECK}
+        if ! echo ${!_attrs} | tr [:lower:] [:upper:] | grep -w -q "${attr}"; then
+            echo "                                        <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
         fi
     done
 
     cat >> ${ATTR_CHECK} <<EOF
+                                </AND>
+                            </NOT>
                         </AND>
 EOF
 done

--- a/usr/local/bin/docker-bootstrap.sh
+++ b/usr/local/bin/docker-bootstrap.sh
@@ -228,7 +228,7 @@ EOF
     # other attributes
     for attr in ${ATTRIBUTES[*]}; do
         if ! echo ${!_attrs} | tr [:lower:] [:upper:] | grep -w -q "${attr}"; then
-            echo "                                    <NOT><Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/></NOT>" >> ${ATTR_CHECK}
+            echo "                                <NOT><Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/></NOT>" >> ${ATTR_CHECK}
         fi
     done
 

--- a/usr/local/bin/docker-bootstrap.sh
+++ b/usr/local/bin/docker-bootstrap.sh
@@ -182,6 +182,26 @@ rm ${TMP_METADATA_1} ${TMP_METADATA_2}
 # generate Shibboleth SP configuration
 #
 
+ATTRIBUTES=(\
+    "ADDRESS" \
+    "COMPANYNAME" \
+    "COUNTYOFBIRTH" \
+    "DATEOFBIRTH" \
+    "DIGITALADDRESS" \
+    "EMAIL" \
+    "EXPIRATIONDATE" \
+    "FAMILYNAME" \
+    "FISCALNUMBER" \
+    "GENDER" \
+    "IDCARD" \
+    "IVACODE" \
+    "MOBILEPHONE" \
+    "NAME" \
+    "PLACEOFBIRTH" \
+    "REGISTEREDOFFICE" \
+    "SPIDCODE" \
+)
+
 # define attribute checker rules
 ATTR_CHECK="/tmp/attr-check.xml"
 cat /dev/null > ${ATTR_CHECK}
@@ -196,8 +216,12 @@ for idx in $(echo ${ACS_INDEXES} | tr ';' ' '); do
                         <AND>
 EOF
 
-    for attr in $(echo ${!_attrs} | tr ';' ' '); do
-        echo "                            <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
+    for attr in ${ATTRIBUTES[*]}; do
+        if echo ${!_attrs} | tr [:lower:] [:upper:] | grep -w -q "${attr}"; then
+            echo "                            <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>"
+        else
+            echo "                            <RuleRegex require=\"$(echo ${attr} | tr [:lower:] [:upper:])\">^\$</RuleRegex>"
+        fi
     done
 
     cat >> ${ATTR_CHECK} <<EOF

--- a/usr/local/bin/docker-bootstrap.sh
+++ b/usr/local/bin/docker-bootstrap.sh
@@ -218,9 +218,9 @@ EOF
 
     for attr in ${ATTRIBUTES[*]}; do
         if echo ${!_attrs} | tr [:lower:] [:upper:] | grep -w -q "${attr}"; then
-            echo "                            <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>"
+            echo "                            <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
         else
-            echo "                            <RuleRegex require=\"$(echo ${attr} | tr [:lower:] [:upper:])\">^\$</RuleRegex>"
+            echo "                            <RuleRegex require=\"$(echo ${attr} | tr [:lower:] [:upper:])\">^\$</RuleRegex>" >> ${ATTR_CHECK}
         fi
     done
 

--- a/usr/local/bin/docker-bootstrap.sh
+++ b/usr/local/bin/docker-bootstrap.sh
@@ -216,26 +216,24 @@ for idx in $(echo ${ACS_INDEXES} | tr ';' ' '); do
                         <AND>
                             <AND>
 EOF
-
+    # required attributes
     for attr in $(echo ${!_attrs} | tr ';' ' '); do
-        echo "      <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
+        echo "                                <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
     done
 
     cat >> ${ATTR_CHECK} <<EOF
                             </AND>
-                            <NOT>
-                                <AND>
+                            <AND>
 EOF
-
+    # other attributes
     for attr in ${ATTRIBUTES[*]}; do
         if ! echo ${!_attrs} | tr [:lower:] [:upper:] | grep -w -q "${attr}"; then
-            echo "                                        <Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/>" >> ${ATTR_CHECK}
+            echo "                                    <NOT><Rule require=\"$(echo ${attr} | tr [:lower:] [:upper:])\"/></NOT>" >> ${ATTR_CHECK}
         fi
     done
 
     cat >> ${ATTR_CHECK} <<EOF
-                                </AND>
-                            </NOT>
+                            </AND>
                         </AND>
 EOF
 done


### PR DESCRIPTION
The checks on returned attributes have been revised in order to check if they are exactly what was requested. In terms of SP configuration, the [access control](https://wiki.shibboleth.net/confluence/display/SP3/XMLAccessControl) rules make now use of `<NOT>` operator in order to check the attributes that are not required. The rules are generated by parsing the `ACS_*` environment variables.

